### PR TITLE
Update maxima

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         image_version: ['alpine', 'debian', 'alpine-latex']
-        os: ['ubuntu-20.04', 'ubuntu-22.04']
+        os: ['ubuntu-22.04']
     runs-on: ${{ matrix.os }}
     steps:
       # https://github.com/actions/checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - '*'
-  schedule:
-    - cron: '30 5 * * 3'
 
 # Set env variables
 env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 # Set env variables
 env:
   DOCKERHUB_USERNAME: ${{secrets.DOCKERHUB_USERNAME}}
-  REPO_NAME: ${{secrets.REPO_NAME}}
+  REPO_NAME: maxima
 
 jobs:
   build-and-push:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
           -t ${DOCKERHUB_USERNAME}/${REPO_NAME}:${{matrix.image_version}} \
           --cache-from=type=gha \
           --cache-to=type=gha,mode=max \
-          . || echo '::error file=Dockerfile.${{matrix.image_version}},title=docker::build failed'
+          .
 
       - name: Push tagged images to docker
         if: ${{ (github.event_name == 'push' || github.event_name == 'pull_request') && github.ref_protected }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 # Set env variables
 env:
-  DOCKER_USER: ${{secrets.DOCKER_USER}}
+  DOCKERHUB_USERNAME: ${{secrets.DOCKERHUB_USERNAME}}
   REPO_NAME: ${{secrets.REPO_NAME}}
 
 jobs:
@@ -37,8 +37,8 @@ jobs:
       - name: Login to Docker
         uses: docker/login-action@v3
         with:
-          username: ${{secrets.DOCKER_USER}}
-          password: ${{secrets.DOCKER_TOKEN}}
+          username: ${{secrets.DOCKERHUB_USERNAME}}
+          password: ${{secrets.DOCKERHUB_TOKEN}}
 
       - name: Build image for ${{matrix.image_version}}, tagging with git SHA and latest
         id: build_image
@@ -48,9 +48,9 @@ jobs:
         run: |
           docker build \
           -f Dockerfile.${{matrix.image_version}} \
-          -t ${DOCKER_USER}/${REPO_NAME}:${{matrix.image_version}}-${GITHUB_SHA} \
-          -t ${DOCKER_USER}/${REPO_NAME}:${{matrix.image_version}}-latest \
-          -t ${DOCKER_USER}/${REPO_NAME}:${{matrix.image_version}} \
+          -t ${DOCKERHUB_USERNAME}/${REPO_NAME}:${{matrix.image_version}}-${GITHUB_SHA} \
+          -t ${DOCKERHUB_USERNAME}/${REPO_NAME}:${{matrix.image_version}}-latest \
+          -t ${DOCKERHUB_USERNAME}/${REPO_NAME}:${{matrix.image_version}} \
           --cache-from=type=gha \
           --cache-to=type=gha,mode=max \
           . || echo '::error file=Dockerfile.${{matrix.image_version}},title=docker::build failed'
@@ -58,4 +58,4 @@ jobs:
       - name: Push tagged images to docker
         if: ${{ (github.event_name == 'push' || github.event_name == 'pull_request') && github.ref_protected }}
         run: |
-          docker push --all-tags $DOCKER_USER/$REPO_NAME
+          docker push --all-tags $DOCKERHUB_USERNAME/$REPO_NAME

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -14,6 +14,7 @@ ENV MaximaPath=/opt/maxima
 
 RUN git clone https://git.code.sf.net/p/maxima/code ${MaximaPath} && \
     cd ${MaximaPath} && \
+    git checkout $maxima_commit && \
     ./bootstrap && \
     ./configure --enable-sbcl --prefix=/usr/local --enable-quiet-build && \
     make install && \

--- a/Dockerfile.alpine-latex
+++ b/Dockerfile.alpine-latex
@@ -17,6 +17,7 @@ ENV MaximaPath=/opt/maxima
 
 RUN git clone https://git.code.sf.net/p/maxima/code ${MaximaPath} && \
     cd ${MaximaPath} && \
+    git checkout $maxima_commit && \
     ./bootstrap && \
     ./configure --enable-sbcl --prefix=/usr/local --enable-quiet-build && \
     make install && \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -24,6 +24,7 @@ ENV MaximaPath=/opt/maxima
 RUN mkdir -p ${MaximaPath} && \
     git clone https://git.code.sf.net/p/maxima/code ${MaximaPath} && \
     cd ${MaximaPath} && \
+    git checkout $maxima_commit && \
     ./bootstrap && \
     ./configure --enable-sbcl --prefix=/usr/local --enable-quiet-build && \
     make install && \

--- a/build.sh
+++ b/build.sh
@@ -8,14 +8,14 @@ IMG_TAG=debian-latest
 
 MAXIMA_COMMIT=314c889bd4bb5a4448f1c7280fb74aa0dcc57edc
 
-docker build -f Dockerfile.debian -t ${DOCKER_USERNAME}/${DOCKER_REPO_BASE}:${IMG_TAG} --build-arg $maxima_commit=$MAXIMA_COMMIT .
+docker build -f Dockerfile.debian -t ${DOCKER_USERNAME}/${DOCKER_REPO_BASE}:${IMG_TAG} --build-arg maxima_commit=$MAXIMA_COMMIT .
 docker push ${DOCKER_USERNAME}/${DOCKER_REPO_BASE}:${IMG_TAG}
 
 # Alpine + Maxima
 DOCKER_REPO_BASE="maxima-docker"
 IMG_TAG=alpine-latest
 
-docker build -f Dockerfile.alpine -t ${DOCKER_USERNAME}/${DOCKER_REPO_BASE}:${IMG_TAG} --build-arg $maxima_commit=$MAXIMA_COMMIT .
+docker build -f Dockerfile.alpine -t ${DOCKER_USERNAME}/${DOCKER_REPO_BASE}:${IMG_TAG} --build-arg maxima_commit=$MAXIMA_COMMIT .
 docker push ${DOCKER_USERNAME}/${DOCKER_REPO_BASE}:${IMG_TAG}
 
 # Alpine + Maxima + LaTeX

--- a/build.sh
+++ b/build.sh
@@ -6,14 +6,16 @@ IFS=$'\n\t'
 DOCKER_REPO_BASE="maxima-docker"
 IMG_TAG=debian-latest
 
-docker build -f Dockerfile.debian -t ${DOCKER_USERNAME}/${DOCKER_REPO_BASE}:${IMG_TAG} .
+MAXIMA_COMMIT=314c889bd4bb5a4448f1c7280fb74aa0dcc57edc
+
+docker build -f Dockerfile.debian -t ${DOCKER_USERNAME}/${DOCKER_REPO_BASE}:${IMG_TAG} --build-arg $maxima_commit=$MAXIMA_COMMIT .
 docker push ${DOCKER_USERNAME}/${DOCKER_REPO_BASE}:${IMG_TAG}
 
 # Alpine + Maxima
 DOCKER_REPO_BASE="maxima-docker"
 IMG_TAG=alpine-latest
 
-docker build -f Dockerfile.alpine -t ${DOCKER_USERNAME}/${DOCKER_REPO_BASE}:${IMG_TAG} .
+docker build -f Dockerfile.alpine -t ${DOCKER_USERNAME}/${DOCKER_REPO_BASE}:${IMG_TAG} --build-arg $maxima_commit=$MAXIMA_COMMIT .
 docker push ${DOCKER_USERNAME}/${DOCKER_REPO_BASE}:${IMG_TAG}
 
 # Alpine + Maxima + LaTeX
@@ -24,5 +26,5 @@ curl -X POST -L https://cloud.docker.com/api/build/v1/source/4813e645-4451-4874-
 #DOCKER_REPO_BASE="maxima-docker"
 #IMG_TAG=alpine-latex-latest
 
-#docker build -f Dockerfile.alpine+latex -t ${DOCKER_USERNAME}/${DOCKER_REPO_BASE}:${IMG_TAG} .
+#docker build -f Dockerfile.alpine+latex -t ${DOCKER_USERNAME}/${DOCKER_REPO_BASE}:${IMG_TAG} --build-arg $maxima_commit=$MAXIMA_COMMIT .
 #docker push ${DOCKER_USERNAME}/${DOCKER_REPO_BASE}:${IMG_TAG}


### PR DESCRIPTION
With the current nightly it is possible to use the argument "--quit-on-error" to quit a batch script on error. This is usefull when testing the tests in a CI and an automated evaluation shall be done
Files: Dockerfile.alpine, Dockerfile.alpine-latex, Dockerfile.debian, and 1 more file